### PR TITLE
Download legacy symbols

### DIFF
--- a/src/Trakx.Kaiko.ApiClient.Tests/Integration/ReferenceDataTests.cs
+++ b/src/Trakx.Kaiko.ApiClient.Tests/Integration/ReferenceDataTests.cs
@@ -67,13 +67,7 @@ public class ReferenceDataTests : IntegrationTestsBase
 
         using var writer = new StreamWriter("kaiko-legacy-symbols.csv");
 
-        void Write(params string[] items)
-        {
-            var line = string.Join(',', items); // .Select(p => $"'{p}")
-            writer.WriteLine(line);
-        }
-
-        Write("kaiko_legacy_symbol", "base_asset", "quote_asset");
+        WriteLineItems(writer, "kaiko_legacy_symbol", "base_asset", "quote_asset");
 
         var currencies = new[] { "usd", "usdc", "eur" };
 
@@ -87,11 +81,17 @@ public class ReferenceDataTests : IntegrationTestsBase
 
         foreach (var d in data)
         {
-            Write(d.Kaiko_legacy_symbol, d.Base_asset, d.Quote_asset);
+            WriteLineItems(writer, d.Kaiko_legacy_symbol, d.Base_asset, d.Quote_asset);
         }
 
         writer.Close();
 
         download.Should().BeTrue();
+    }
+
+    private static void WriteLineItems(StreamWriter writer, params string[] items)
+    {
+        var line = string.Join(',', items);
+        writer.WriteLine(line);
     }
 }

--- a/src/Trakx.Kaiko.ApiClient.Tests/Integration/ReferenceDataTests.cs
+++ b/src/Trakx.Kaiko.ApiClient.Tests/Integration/ReferenceDataTests.cs
@@ -51,4 +51,50 @@ public class ReferenceDataTests : IntegrationTestsBase
         response.Result.Data.Should().NotBeNull();
         response.Result.Data.Should().HaveCountGreaterThan(0);
     }
+
+    [InlineData(false)]
+    [Theory]
+    public async Task Download_legacy_symbols(bool download)
+    {
+        if (!download)
+        {
+            download.Should().BeFalse();
+            return;
+        }
+
+        var client = ServiceProvider.GetRequiredService<IInstrumentsClient>();
+        var response = await client.GetAllInstrumentsAsync();
+
+        using var writer = new StreamWriter("kaiko-legacy-symbols.csv");
+
+        void Write(params string[] items)
+        {
+            var line = string.Join(',', items); // .Select(p => $"'{p}")
+            writer.WriteLine(line);
+        }
+
+        Write("kaiko_legacy_symbol", "base_asset", "quote_asset");
+
+        var seen = new HashSet<string>();
+
+        var currencies = new[] { "usd", "usdc", "eur" };
+
+        var data = response.Result.Data
+            .Where(p => p.Class == "spot")
+            .Where(p => !string.IsNullOrWhiteSpace(p.Kaiko_legacy_symbol))
+            .Where(p => !p.Kaiko_legacy_symbol.StartsWith("0x"))
+            .Where(p => currencies.Contains(p.Quote_asset))
+            .DistinctBy(p => p.Kaiko_legacy_symbol)
+            .OrderBy(p => p.Kaiko_legacy_symbol);
+
+        foreach (var d in data)
+        {
+            if (seen.Contains(d.Kaiko_legacy_symbol)) continue;
+            Write(d.Kaiko_legacy_symbol, d.Base_asset, d.Quote_asset);
+        }
+
+        writer.Close();
+
+        download.Should().BeTrue();
+    }
 }

--- a/src/Trakx.Kaiko.ApiClient.Tests/Integration/ReferenceDataTests.cs
+++ b/src/Trakx.Kaiko.ApiClient.Tests/Integration/ReferenceDataTests.cs
@@ -75,8 +75,6 @@ public class ReferenceDataTests : IntegrationTestsBase
 
         Write("kaiko_legacy_symbol", "base_asset", "quote_asset");
 
-        var seen = new HashSet<string>();
-
         var currencies = new[] { "usd", "usdc", "eur" };
 
         var data = response.Result.Data
@@ -89,7 +87,6 @@ public class ReferenceDataTests : IntegrationTestsBase
 
         foreach (var d in data)
         {
-            if (seen.Contains(d.Kaiko_legacy_symbol)) continue;
             Write(d.Kaiko_legacy_symbol, d.Base_asset, d.Quote_asset);
         }
 


### PR DESCRIPTION
As Kaiko use a 'legacy symbols' code in S3 buckets, we need to get a mapping between the legacy symbols and the trade pair.

This PR adds a unit test (disabled by default) as a quick way to download the information from the public Reference Data REST api and save in a local `kaiko-legacy-symbols.csv`.