### PR TITLE
Multiple timestamps in response. Allow all exchanges via wildcard.

### DIFF
--- a/src/Trakx.Kaiko.ApiClient.Stream.Tests/Trakx.Kaiko.ApiClient.Stream.Tests.csproj
+++ b/src/Trakx.Kaiko.ApiClient.Stream.Tests/Trakx.Kaiko.ApiClient.Stream.Tests.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="5.0.0" />
     <PackageReference Include="NSubstitute" Version="5.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="Trakx.Common.Testing.Documentation" Version="0.2.1" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/Trakx.Kaiko.ApiClient.Stream/Models/MarketUpdateRequest.cs
+++ b/src/Trakx.Kaiko.ApiClient.Stream/Models/MarketUpdateRequest.cs
@@ -11,6 +11,9 @@ public class MarketUpdateRequest
     [JsonPropertyName("quoteSymbols")]
     public string[] QuoteSymbols { get; set; } = Array.Empty<string>();
 
+    /// <summary>
+    /// What exchanges to include in the response. If empty, all available exchanges will be included.
+    /// </summary>
     [JsonPropertyName("exchanges")]
     public string[] Exchanges { get; set; } = Array.Empty<string>();
 

--- a/src/Trakx.Kaiko.ApiClient.Stream/Models/MarketUpdateResponse.cs
+++ b/src/Trakx.Kaiko.ApiClient.Stream/Models/MarketUpdateResponse.cs
@@ -23,6 +23,12 @@ public class MarketUpdateResponse
     [JsonPropertyName("timestamp")]
     public DateTimeOffset Timestamp { get; set; }
 
+    [JsonPropertyName("timestampExchange")]
+    public DateTimeOffset? TimestampExchange { get; set; }
+
+    [JsonPropertyName("timestampCollection")]
+    public DateTimeOffset? TimestampCollection { get; set; }
+
     [JsonPropertyName("updateType")]
     public string UpdateType { get; set; } = string.Empty;
 


### PR DESCRIPTION
In our response wrapper, include all three timestamps coming from Kaiko - event, exchange and collection.

It's possible to request data from all supported exchanges via a `*` wildcard.
When making a request, an empty `Exchanges` will default to including all exchanges.