### PR TITLE
Price field and double data type

### DIFF
--- a/src/Trakx.Kaiko.ApiClient/MarketData/MarketDataClients.cs
+++ b/src/Trakx.Kaiko.ApiClient/MarketData/MarketDataClients.cs
@@ -839,16 +839,16 @@ namespace Trakx.Kaiko.ApiClient
         public long Timestamp { get; set; }
 
         [Newtonsoft.Json.JsonProperty("open", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public float? Open { get; set; }
+        public double? Open { get; set; }
 
         [Newtonsoft.Json.JsonProperty("high", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public float? High { get; set; }
+        public double? High { get; set; }
 
         [Newtonsoft.Json.JsonProperty("low", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public float? Low { get; set; }
+        public double? Low { get; set; }
 
         [Newtonsoft.Json.JsonProperty("close", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public float? Close { get; set; }
+        public double? Close { get; set; }
 
         [Newtonsoft.Json.JsonProperty("volume", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double? Volume { get; set; }
@@ -888,7 +888,7 @@ namespace Trakx.Kaiko.ApiClient
         /// Volume-weighted average price. null when no trades reported.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("price", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public float? Price { get; set; }
+        public double? Price { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -922,16 +922,19 @@ namespace Trakx.Kaiko.ApiClient
         public long? Count { get; set; }
 
         [Newtonsoft.Json.JsonProperty("open", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public float? Open { get; set; }
+        public double? Open { get; set; }
 
         [Newtonsoft.Json.JsonProperty("high", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public float? High { get; set; }
+        public double? High { get; set; }
 
         [Newtonsoft.Json.JsonProperty("low", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public float? Low { get; set; }
+        public double? Low { get; set; }
 
         [Newtonsoft.Json.JsonProperty("close", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public float? Close { get; set; }
+        public double? Close { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("price", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double? Price { get; set; }
 
         [Newtonsoft.Json.JsonProperty("volume", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double? Volume { get; set; }

--- a/src/Trakx.Kaiko.ApiClient/marketData.openApi3.yaml
+++ b/src/Trakx.Kaiko.ApiClient/marketData.openApi3.yaml
@@ -342,19 +342,19 @@ components:
           $ref: '#/components/schemas/Timestamp'
         open:
           type: number
-          format: float
+          format: double
           nullable: true
         high:
           type: number
-          format: float
+          format: double
           nullable: true
         low:
           type: number
-          format: float
+          format: double
           nullable: true
         close:
           type: number
-          format: float
+          format: double
           nullable: true
         volume:
           type: number
@@ -380,7 +380,7 @@ components:
         price:
           description: Volume-weighted average price. null when no trades reported.
           type: number
-          format: float
+          format: double
           nullable: true
 
     AggregateCountOhlcvVwapResponse:
@@ -404,19 +404,23 @@ components:
           nullable: true
         open:
           type: number
-          format: float
+          format: double
           nullable: true
         high:
           type: number
-          format: float
+          format: double
           nullable: true
         low:
           type: number
-          format: float
+          format: double
           nullable: true
         close:
           type: number
-          format: float
+          format: double
+          nullable: true
+        price:
+          type: number
+          format: double
           nullable: true
         volume:
           type: number


### PR DESCRIPTION
Added missed `price` field.
In my defense, it's not shown as a field in the documentation:
<https://docs.kaiko.com/#count-ohlcv-vwap>
![image](https://github.com/trakx/kaiko-api-client/assets/161576/817a44c1-efc0-4b19-a9e9-3aaff9c2982b)
(It's only shown in the sample response)

Also changed all numeric types to `double` instead of `float`.
